### PR TITLE
fullhash 修改为 chunkhash

### DIFF
--- a/config/webpack.build.common.js
+++ b/config/webpack.build.common.js
@@ -15,8 +15,9 @@ module.exports = function(type, puzzle) {
     entry,
     output: {
       path: resolve(`dist/${type}/${puzzle}`),
+      // publicPath: `./${type}/${puzzle}/`,
       filename: "[name].js",
-      chunkFilename: "[name].[fullhash].js",
+      chunkFilename: "[name].[chunkhash].js",
       library: `${type}_${puzzle}`,
       libraryTarget: "umd"
     },

--- a/config/webpack.build.core.js
+++ b/config/webpack.build.core.js
@@ -18,11 +18,11 @@ const webpackConfig = {
   output: {
     path: resolve("dist/core"),
     publicPath: "./core/",
-    filename: "[name].[fullhash].js",
+    filename: "[name].[chunkhash].js",
     // libraryTarget: "var"
     library: {
       type: "var",
-      name: "[name]_[fullhash]"
+      name: "[name]_puzzle"
     }
   },
   // devtool: "source-map",

--- a/config/webpack.build.dll.js
+++ b/config/webpack.build.dll.js
@@ -20,15 +20,20 @@ module.exports = {
     puzzle: ["moment"]
   },
   output: {
-    filename: "[name].[fullhash].dll.js",
+    filename: "[name]/[name].[chunkhash].dll.js",
     path: path.join(__dirname, "../static/dll"),
-    library: "[name]_[fullhash]"
+    library: "[name]_puzzleDll",
+    libraryTarget: "umd"
   },
   plugins: [
     new CleanWebpackPlugin(),
     new webpack.DllPlugin({
-      path: path.join(__dirname, "../static/dll", "[name].manifest.json"),
-      name: "[name]_[fullhash]"
+      path: path.join(
+        __dirname,
+        "../static/dll/[name]",
+        "[name].[chunkhash].manifest.json"
+      ),
+      name: "[name]_puzzleDll"
     })
   ]
 };

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -4,9 +4,25 @@ const VueLoaderPlugin = require("vue-loader/lib/plugin");
 // 路径获取
 const resolve = require("./utils").resolve;
 
+const path = require("path")
+const requireContext = require("./utils").requireContext
+
+const getManifest = dir => {
+  let fileName
+  const manifestList = requireContext(
+    path.resolve(__dirname, `../static/dll/${dir}`),
+    false,
+    /\.manifest\.json$/
+  )
+  Object.keys(manifestList).forEach(name => {
+    fileName = name
+  })
+  return path.resolve(__dirname, `../static/dll/${dir}/${fileName}.json`)
+}
+
 module.exports = {
   output: {
-    filename: "[name].bundle.[fullhash].js",
+    filename: "[name].bundle.[chunkhash].js",
     path: resolve("dist/frame")
   },
   resolve: {
@@ -43,7 +59,7 @@ module.exports = {
         use: [
           {
             loader: "file-loader",
-            options: { outputPath: "img" }
+            options: { outputPath: "img", esModule: false }
           }
         ]
       },
@@ -62,10 +78,10 @@ module.exports = {
     new VueLoaderPlugin(),
     // dll
     new webpack.DllReferencePlugin({
-      manifest: require("../static/dll/core.manifest.json")
+      manifest: require(getManifest("core"))
     }),
     new webpack.DllReferencePlugin({
-      manifest: require("../static/dll/puzzle.manifest.json")
+      manifest: require(getManifest("puzzle"))
     })
   ]
 };


### PR DESCRIPTION
-fix: fullhash 修改为 chunkhash
之前升级 webpack5 时只是简单的用 fullhash 替换了 hash，一旦某个 puzzle 中文件发生改变，fullhash 也会改变，整个项目都需要重新打包，无法做到局部更新和替换，因此用 chunkhash 替换之前使用的 fullhash

-chore: dll 划分为 core 和 puzzle 目录
dll 打包后 static 的子目录会划分为 core 和 puzzle，便于替换 dll 资源